### PR TITLE
Changed configuration file handling

### DIFF
--- a/myreddit-dl/defaults.py
+++ b/myreddit-dl/defaults.py
@@ -23,39 +23,39 @@ class Defaults:
         utils.print_info(f'Path set to default: {default_path}')
 
 
-    def set_config_save(self, save_as: str) -> None:
-        save_as = save_as.lower()
-        if save_as != utils.CFG_SAVE_DEFAULT and save_as != 'username':
+    def set_config_prefix(self, prefix: str) -> None:
+        prefix = prefix.lower()
+        if prefix != utils.CFG_PREFIX_DEFAULT and prefix != 'username':
             utils.print_error(utils.INVALID_CFG_OPTION)
             return
 
         self.config.read(utils.CFG_FILENAME)
-        if save_as == self.config['DEFAULT']['filename_save']:
-            utils.print_info('This is already the current set saving option.')
+        if prefix == self.config['DEFAULT']['filename_prefix']:
+            utils.print_info('This is already the current set prefix option.')
             return
 
         # Different valid option given (username or subreddit)
         try:
-            self.__write_config('DEFAULT', 'filename_save', save_as)
-            utils.print_info(f'Save format changed to: {save_as}')
+            self.__write_config('DEFAULT', 'filename_prefix', prefix)
+            utils.print_info(f'Prefix format changed to: {prefix}')
 
         except BaseException:
             utils.print_error(
-                'Something went wrong changing the saving format.')
+                'Something went wrong changing the prefix format.')
             exit(1)
 
     def set_base_path(self, path: str) -> None:
+        sanitized_path = self._sanitize_path(path)
         self.config.read(utils.CFG_FILENAME)
-        if os.path.exists(path):
-            self.__write_config('DEFAULT', 'path', path)
-            utils.print_info(f'Path set to: {path}')
+        if os.path.exists(sanitized_path):
+            self.__write_config('DEFAULT', 'path', sanitized_path)
+            utils.print_info(f'Path set to: {sanitized_path}')
             return
 
-        sanitized_path = self._sanitize_path(path)
 
         if sanitized_path is not None:
-            self.__write_config('DEFAULT', 'path', path)
-            utils.print_info(f'Path set to: {path}')
+            self.__write_config('DEFAULT', 'path', sanitized_path)
+            utils.print_info(f'Path set to: {sanitized_path}')
 
 
     def _sanitize_path(self, path: str) -> str or None:
@@ -86,7 +86,7 @@ class Defaults:
 
     def get_file_prefix(self) -> str:
         self.config.read(utils.CFG_FILENAME)
-        return str(self.config['DEFAULT']['filename_save'])
+        return str(self.config['DEFAULT']['filename_prefix'])
 
     def get_base_path(self) -> str:
         if self.debug:

--- a/myreddit-dl/downloader.py
+++ b/myreddit-dl/downloader.py
@@ -304,8 +304,8 @@ class Downloader:
                 return
 
     def start(self) -> None:
-        if self.args['config_save']:
-            Defaults().set_config_save(str(self.args['config_save']))
+        if self.args['config_prefix']:
+            Defaults().set_config_prefix(str(self.args['config_prefix']))
             exit(0)
 
         if self.args['config_path']:

--- a/myreddit-dl/downloader.py
+++ b/myreddit-dl/downloader.py
@@ -310,7 +310,7 @@ class Downloader:
 
         if self.args['config_path']:
             if self.args['config_path'].lower() == 'default':
-                Defaults().set_path_to_default(str(self.user))
+                Defaults().set_path_to_default()
             else:
                 Defaults().set_base_path(str(self.args['config_path']))
             exit(0)

--- a/myreddit-dl/myreddit-dl.py
+++ b/myreddit-dl/myreddit-dl.py
@@ -40,12 +40,20 @@ def get_cli_args():
         required=False)
 
     config_group.add_argument(
-        '--config-save',
+        '--config-prefix',
         type=str,
         default=None,
         help=textwrap.dedent('''\
-        change how the filenames are saved as (username_id.ext or subreddit_id.ext).
-        Defaults: subreddit
+        change how the filenames are prefixed (post author username and/or post subreddit name)
+
+        Options:
+
+            '--config-prefix username'           ---> username_id.extension
+            '--config-prefix username subreddit' ---> username_subreddit_id.extension
+            '--config-prefix subreddit username' ---> subreddit_username_id.exension
+            '--config-prefix subreddit'          ---> subreddit_id.exension
+
+        Default: subreddit ---> subreddit_id.extension
 
         '''),
         metavar='OPT',
@@ -59,8 +67,17 @@ def get_cli_args():
         path to the folder were media will be downloaded to
 
         Examples:
-        --config-path $HOME/media_chosen_folder/custom_chosen_folder/
-        --config-path ~/random/destination_folder/
+
+        To download the media to the folder ~/Pictures/reddit_media:
+            --config-path $HOME/Pictures/reddit_media
+                                or
+            --config-path ~/Pictures/reddit_media
+
+        To download the media to the current working directory:
+            --config-path ./
+
+        To download the media to a folder in the current working directory
+            --config-path ./random_folder_destination
 
         Default Path: $HOME/Pictures/User_myreddit/
         '''),

--- a/myreddit-dl/utils.py
+++ b/myreddit-dl/utils.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 
+# TODO: refactor this entire file.
 
 # Project directory: myreddit-dl/myreddit-dl/
 PROJECT_DIR = str(Path(__file__).parent) + os.sep
@@ -9,7 +10,7 @@ PROJECT_PARENT_DIR = str(Path(__file__).parent.parent) + os.sep
 
 # config file
 CFG_FILENAME = PROJECT_DIR + 'config.ini'
-CFG_SAVE_DEFAULT = 'subreddit'
+CFG_PREFIX_DEFAULT = 'subreddit'
 
 INVALID_CFG_OPTION = ('Invalid save option.\n\n'
                       'Valid Options:\n'


### PR DESCRIPTION
- Refactored `--config-save` flag to `--config-prefix` to better match the true behavior of said flag.
- Updated argparser with better explanations on `--config-prefix` and `--config-path` flags.
- Fixed bug were the `path` key begin empty in the `config.ini` file caused crash.
- Added better `default_path` handling.