### PR TITLE
Added client configurator via terminal

### DIFF
--- a/myreddit-dl/downloader.py
+++ b/myreddit-dl/downloader.py
@@ -29,9 +29,8 @@ class Downloader:
 
     @property
     def __print_counters(self) -> None:
-        if self.client.args['debug'] or self.client.args['verbose']:
-            utils.print_info(f'{self.download_counter} items downloaded.')
-            utils.print_info(f'{self.items_iterated} posts iterated.')
+        utils.print_info(f'{self.download_counter} items downloaded.')
+        utils.print_info(f'{self.items_iterated} posts iterated.')
 
     @property
     def item(self) -> 'RedditPostItem':
@@ -305,18 +304,8 @@ class Downloader:
                 exit(0)
                 return
 
+
     def start(self) -> None:
-
-        if self.args['config_prefix']:
-            Defaults().set_config_prefix(self.args['config_prefix'])
-            exit(0)
-
-        if self.args['config_path']:
-            if self.args['config_path'].lower() == 'default':
-                Defaults().set_path_to_default()
-            else:
-                Defaults().set_base_path(str(self.args['config_path']))
-            exit(0)
 
         if self.client.args['nsfw']:
             self.valid_domains = self.sfw_domains.union(self.nsfw_domains)

--- a/myreddit-dl/myreddit-dl.py
+++ b/myreddit-dl/myreddit-dl.py
@@ -22,6 +22,7 @@ def get_cli_args():
 
     required_group = parser.add_argument_group(
         'Required Arguments (only required to download)')
+
     config_group = parser.add_argument_group('Configuration')
     metadata_group = parser.add_argument_group('Metadata')
 
@@ -37,6 +38,24 @@ def get_cli_args():
         '--saved',
         action='store_true',
         help="Download saved media",
+        required=False)
+
+    config_group.add_argument(
+        '--client-config',
+        action='store_true',
+        help="change the reddit app client information (id, secret, username, password)",
+        required=False)
+
+    config_group.add_argument(
+        '--get-config',
+        action='store_true',
+        help="prints the configuration file information to the terminal",
+        required=False)
+
+    config_group.add_argument(
+        '--get-config-show',
+        action='store_true',
+        help="prints the configuration file information to the terminal and show password",
         required=False)
 
     config_group.add_argument(
@@ -186,7 +205,7 @@ def run():
     # GUI version of the app
     else:
         print('GUI version coming soon...')
-        #run_gui()
+        # run_gui()
 
 
 if __name__ == '__main__':

--- a/myreddit-dl/reddit_client.py
+++ b/myreddit-dl/reddit_client.py
@@ -1,6 +1,7 @@
 import configparser
 import praw
 import utils
+from terminal import Terminal
 
 
 class RedditClient:
@@ -9,26 +10,58 @@ class RedditClient:
         self.arg_dict = arg_dict
         self.config = configparser.ConfigParser()
         self.config.read(utils.CFG_FILENAME)
+        self.__check_config_request()
 
         self.username = None
         self.reddit_instance = self.build_reddit_instance()
+        self.__check_instance_validity()
 
-    def build_reddit_instance(self) -> praw.Reddit:
+    def build_reddit_instance(self) -> praw.Reddit or None:
         instance = praw.Reddit(
             user_agent='MyReddit-dl',
             client_id=self.config['REDDIT']['client_id'],
             client_secret=self.config['REDDIT']['client_secret'],
             username=self.config['REDDIT']['username'],
             password=self.config['REDDIT']['password'])
-        try:
-            self.username = instance.user.me()
-            utils.print_info('Reddit Instance build status: OK!\n')
-            return instance
 
+        try:
+            if instance.user.me() is not None:
+                self.username = instance.user.me()
+                utils.print_info('Reddit Instance build status: OK!\n')
+                return instance
         except BaseException:
-            utils.print_info('Reddit Instance build status: Failed.')
-            utils.print_error(utils.USER_NOT_FOUND)
-            exit(1)
+            return None
+        return None
+
+    def __check_instance_validity(self) -> None:
+        if self.reddit_instance is None:
+            Terminal().prompt_client_config_setup()
+            self.__init__(self.arg_dict)
+        return
+
+    def __check_config_request(self):
+        if self.arg_dict['client_config']:
+            Terminal().client_config_setup()
+            exit(0)
+        elif self.arg_dict['get_config']:
+            Terminal().print_config_data()
+            exit(0)
+        elif self.arg_dict['get_config_show']:
+            Terminal().print_config_data(True)
+            exit(0)
+        elif self.arg_dict['config_prefix']:
+            from defaults import Defaults
+            Defaults().set_config_prefix(self.args['config_prefix'])
+            exit(0)
+
+        elif self.arg_dict['config_path']:
+            from defaults import Defaults
+            if self.args['config_path'].lower() == 'default':
+                Defaults().set_path_to_default()
+            else:
+                Defaults().set_base_path(str(self.args['config_path']))
+            exit(0)
+        return
 
     @property
     def max_depth(self):

--- a/myreddit-dl/terminal.py
+++ b/myreddit-dl/terminal.py
@@ -1,0 +1,68 @@
+import configparser
+import getpass
+import utils
+
+
+class Terminal:
+    def __init__(self):
+        self.config = configparser.ConfigParser()
+        self.config.read(utils.CFG_FILENAME)
+
+    def client_config_setup(self):
+        self._config_setup_header()
+        client_id = input('1. Client Id: ').strip(' ')
+        client_secret = input('2. Client Secret: ').strip(' ')
+        username = input('3. Username: ').strip(' ')
+        password = getpass.getpass('4. Password (hidden): ').strip(' ')
+
+        self.config.set('REDDIT', 'client_id', client_id)
+        self.config.set('REDDIT', 'client_secret', client_secret)
+        self.config.set('REDDIT', 'username', username)
+        self.config.set('REDDIT', 'password', password)
+
+        with open(utils.CFG_FILENAME, 'w') as config_file:
+            self.config.write(config_file)
+            print('\nReddit developer app updated succesfully.\n')
+        return
+
+    def _config_setup_header(self):
+        instructions = utils.DEVELOPER_APP_INSTRUCTIONS
+        header = '-' * 20 + ' SETUP CONFIGURATOR ' + '-' * 20
+        print('\n' + header)
+        print(
+            'For information'
+            ' on how to setup your own developer credentials to use myreddit-dl,\n'
+            'Please refer to',
+            instructions)
+
+        print(
+            '\nInput your reddit developer credentials below. Make sure they are correct.\n')
+        print('-' * len(header))
+
+    def prompt_client_config_setup(self):
+        print()
+        utils.print_warning(
+            'Either this is your first time using myreddit-dl'
+            ' or there appear to be a problem in your reddit app'
+            ' client information.\n\n')
+        response = ''
+        while response not in {'y', 'yes', 'n', 'no'}:
+            response = input('Would you like to fix it? (y)es, (n)o: ').lower()
+
+        if response == 'n' or response == 'no':
+            exit(0)
+        return self.client_config_setup()
+
+    def print_config_data(self, show_password=False):
+        print('Current Configuration:')
+
+        print('\n[DEFAULT]\n')
+        print('Prefix:', self.config['DEFAULT']['filename_prefix'])
+        print('Path:', self.config['DEFAULT']['path'])
+
+        print('\n[REDDIT]\n')
+        print('Client Id:', self.config['REDDIT']['client_id'])
+        print('Client Secret:', self.config['REDDIT']['client_secret'])
+        print('Username:', self.config['REDDIT']['username'])
+        if show_password:
+            print('Password:', self.config['REDDIT']['password'])

--- a/myreddit-dl/utils.py
+++ b/myreddit-dl/utils.py
@@ -13,6 +13,9 @@ CFG_FILENAME = PROJECT_DIR + 'config.ini'
 CFG_PREFIX_DEFAULT = 'subreddit'
 
 
+DEVELOPER_APP_INSTRUCTIONS = ('https://github.com/emanuel2718/myreddit-dl'
+                              '/blob/master/PRE_INSTALL.md')
+
 
 INVALID_CFG_OPTION_MESSAGE = ('Invalid save option.\n\n'
                               'Valid Options:\n'
@@ -20,6 +23,8 @@ INVALID_CFG_OPTION_MESSAGE = ('Invalid save option.\n\n'
                               '2. --config-prefix subreddit\n'
                               '3. --config-prefix subreddit username\n'
                               '4. --config-prefix username subreddit\n')
+
+
 
 # Domains and usefuls urls
 REDDIT_GALLERY_URL = 'https://www.reddit.com/gallery/'
@@ -34,7 +39,7 @@ EXTENSION_STRING = '.jpg.png.jpeg.gif.gifv.mp4'
 DONT_RUN_THIS_FILE = ('This file is not intended to be run by itself. '
                       'See myreddit-dl -h for more information')
 
-USER_NOT_FOUND = 'User not found. Make sure the `config.ini` file is correct.\n'
+USER_NOT_FOUND = 'User not found. Possible error in the `config.ini` file.\n'
 
 MISSING_STORING_METHOD = (
     'Required argument missing.\n\n'


### PR DESCRIPTION
- Added `client_config` flag that let the user change the Reddit client credentials.
- Added `get-config` and `get-config-show` flags that prints the entire configurations to the terminal (with `show` the user Reddit client password will also be printed).
- Added new file `terminal.py` that will handle all the terminal-user interactions.
- Moved the `config` flags to `reddit_client.py` from `downloader.py`