### PR TITLE
Add client and Change client flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 __*
-myreddit-dl/config.ini
 myreddit-dl/config.backup
 debug_media/
 debug_log

--- a/myreddit-dl/defaults.py
+++ b/myreddit-dl/defaults.py
@@ -5,6 +5,7 @@ import os
 from platform import system
 
 # TODO: Make this have the args...
+# TODO: Refactor this whole entire file.
 
 class Defaults:
     def __init__(self, debug=False) -> None:
@@ -29,7 +30,11 @@ class Defaults:
 
     @property
     def user_section_name(self) -> str:
-        ''' Returns the current user config [SECTION] name'''
+        '''
+        Returns the current user config [SECTION] name
+
+        @return: str: current user section name.
+        '''
         return str(self.config['USERS']['current_user_section_name'])
 
     @property
@@ -53,7 +58,7 @@ class Defaults:
 
     def set_path_to_default(self) -> None:
         default_path = self.default_config_path
-        self.__write_config(f'DEFAULT', 'path', default_path)
+        self.__write_config(f'DEFAULTS', 'path', default_path)
         self.log.info(f'Path set to myreddit-dl default path: {default_path}')
 
     def set_config_prefix(self, prefix: list) -> None:
@@ -63,13 +68,13 @@ class Defaults:
         if given not in valid_options:
             self.log.error(utils.INVALID_CFG_OPTION_MESSAGE)
             return
-        if given == self.config['DEFAULT']['filename_prefix']:
+        if given == self.config['DEFAULTS']['prefix']:
             self.log.info('This is already the current set prefix option.')
             return
 
         # Different valid option given (username or subreddit)
         try:
-            self.__write_config('DEFAULT', 'filename_prefix', given)
+            self.__write_config('DEFAULTS', 'prefix', given)
             self.log.info(f'Prefix format changed to: {given}')
 
         except BaseException:
@@ -79,7 +84,7 @@ class Defaults:
     def set_base_path(self, path: str) -> None:
         sanitized_path = self._sanitize_path(path)
         if os.path.exists(sanitized_path) or sanitized_path is not None:
-            self.__write_config('DEFAULT', 'path', sanitized_path)
+            self.__write_config('DEFAULTS', 'path', sanitized_path)
             self.log.info(f'Path set to: {sanitized_path}')
             return
 
@@ -115,7 +120,7 @@ class Defaults:
         return self.media_folder + self.username + '_metadata.json'
 
     def get_file_prefix(self) -> str:
-        return str(self.config['DEFAULT']['filename_prefix'])
+        return str(self.config['DEFAULTS']['prefix'])
 
     def get_base_path(self, clean=False) -> str:
         if self.debug or clean:
@@ -124,9 +129,10 @@ class Defaults:
                 f"{str(utils.PROJECT_PARENT_DIR + 'debug_media' + os.sep)}")
             return str(utils.PROJECT_PARENT_DIR + 'debug_media' + os.sep)
 
-        config_path = str(self.config['DEFAULT']['path'])
-        if self.is_valid_path(config_path):
-            return config_path
+        if len(self.config['DEFAULTS']['path']) != 0:
+            config_path = str(self.config['DEFAULTS']['path'])
+            if self.is_valid_path(config_path):
+                return config_path
 
         self.set_path_to_default()
         return self.default_config_path
@@ -142,41 +148,3 @@ class Defaults:
             self.log.info(f'Removed debug folder: {debug_path}')
         except BaseException:
             self.log.info(f'Debug folder not found.')
-
-# [DEFAULT]
-# prefix =
-# path =
-#
-# [USERS]
-# all_users = ZENS167, LOGNEPI
-# current_user = LOGNEPI # This points to the current user. Refactor 'REDDIT'
-#
-#
-# [LOGENPI]
-# client_id =
-# client_secret =
-# username =
-# password =
-#
-#
-#
-#
-# myreddit-dl --add-user zens167
-#
-# > check if user exists in ['USERS']['all_users']
-# > prompt config
-# > add user to ['USERS']['all_users']
-#
-#
-# [ZENS167]
-# client_id =
-# client_secret =
-# username =
-# password =
-#
-#
-# myreddit-dl --change-user lognepi
-#
-# >prompt available users with 1, 2, 3...n = exit options
-# >check if arg.upper() in 'all_users'
-# >change current_user > arg.upper()

--- a/myreddit-dl/myreddit.py
+++ b/myreddit-dl/myreddit.py
@@ -64,18 +64,11 @@ def get_cli_args():
 
     config_group.add_argument(
         '--change-client',
-        type=str,
+        action='store_true',
         help=textwrap.dedent('''\
         change to another valid existing reddit client (account)
-        must provide valid reddit username.
-
-        Example:
-            --change-client randomRedditUsername
-
-        Note: account must have been previously added with --add-client
 
         '''),
-        metavar='User',
         required=False)
 
     config_group.add_argument(

--- a/myreddit-dl/myreddit.py
+++ b/myreddit-dl/myreddit.py
@@ -43,13 +43,39 @@ def get_cli_args():
         help="Download saved media",
         required=False)
 
+
     config_group.add_argument(
-        '--config-client',
+        '--add-client',
         action='store_true',
         help=textwrap.dedent('''\
-        change the reddit app client information (id, secret, username, password)
+        add new reddit account
 
         '''),
+        required=False)
+
+    config_group.add_argument(
+        '--add-client-hidden',
+        action='store_true',
+        help=textwrap.dedent('''\
+        add new reddit account with password prompt hidden
+
+        '''),
+        required=False)
+
+    config_group.add_argument(
+        '--change-client',
+        type=str,
+        help=textwrap.dedent('''\
+        change to another valid existing reddit client (account)
+        must provide valid reddit username.
+
+        Example:
+            --change-client randomRedditUsername
+
+        Note: account must have been previously added with --add-client
+
+        '''),
+        metavar='User',
         required=False)
 
     config_group.add_argument(
@@ -62,10 +88,10 @@ def get_cli_args():
 
         Options:
 
-            '--config-prefix username'           ---> username_id.extension
-            '--config-prefix username subreddit' ---> username_subreddit_id.extension
-            '--config-prefix subreddit username' ---> subreddit_username_id.exension
-            '--config-prefix subreddit'          ---> subreddit_id.exension
+            --config-prefix username           ---> username_id.extension
+            --config-prefix username subreddit ---> username_subreddit_id.extension
+            --config-prefix subreddit username ---> subreddit_username_id.exension
+            --config-prefix subreddit          ---> subreddit_id.exension
 
         Default: subreddit ---> subreddit_id.extension
 

--- a/myreddit-dl/reddit_client.py
+++ b/myreddit-dl/reddit_client.py
@@ -22,12 +22,22 @@ class RedditClient(Defaults):
     def build_reddit_instance(self) -> praw.Reddit or None:
         self.log.debug('Building reddit instance')
 
-        instance = praw.Reddit(
-            user_agent = 'MyReddit-dl',
-            client_id = self.config[self.user_section_name]['client_id'],
-            client_secret = self.config[self.user_section_name]['client_secret'],
-            username = self.config[self.user_section_name]['username'],
-            password = self.config[self.user_section_name]['password'])
+        if len(self.user_section_name) == 0:
+            Terminal().client_config_setup(self.arg_dict['add_client_hidden'])
+            exit(0)
+
+
+        try:
+            instance = praw.Reddit(
+                user_agent = 'MyReddit-dl',
+                client_id = self.config[self.user_section_name]['client_id'],
+                client_secret = self.config[self.user_section_name]['client_secret'],
+                username = self.config[self.user_section_name]['username'],
+                password = self.config[self.user_section_name]['password'])
+
+        except BaseException:
+            Terminal().client_config_setup(self.arg_dict['add_client_hidden'])
+            self.build_reddit_instance()
 
         try:
             if instance.user.me() is not None:
@@ -43,16 +53,21 @@ class RedditClient(Defaults):
             return None
         return None
 
+
     def __check_instance_validity(self) -> None:
         if self.reddit_instance is None:
-            Terminal().prompt_client_config_setup()
-            self.log.info('Client configuration status: Done\n\n')
-            self.__init__(self.arg_dict)
+            Terminal().prompt_client_config_setup(self.arg_dict['add_client_hidden'])
+            self.log.info('Client configuration status: Done\n')
+            exit(0)
         return
 
     def __check_config_request(self):
-        if self.arg_dict['config_client']:
+        if self.arg_dict['add_client']:
             Terminal().client_config_setup()
+            exit(0)
+        if self.arg_dict['change_client']:
+            Terminal().change_client(self.arg_dict['change_client'])
+            #self.set_path_to_default()
             exit(0)
         elif self.arg_dict['config_prefix']:
             from defaults import Defaults

--- a/myreddit-dl/reddit_client.py
+++ b/myreddit-dl/reddit_client.py
@@ -4,35 +4,40 @@ import utils
 import logging
 import logging.handlers
 from terminal import Terminal
+from defaults import Defaults
 
 
-class RedditClient:
+class RedditClient(Defaults):
 
     def __init__(self, arg_dict: dict) -> None:
+        super().__init__()
         self.log = utils.setup_logger(__name__, arg_dict['debug'])
         self.arg_dict = arg_dict
-        self.config = configparser.ConfigParser()
-        self.config.read(utils.CFG_FILENAME)
+        self.user_instance = None
         self.__check_config_request()
 
-        self.username = None
         self.reddit_instance = self.build_reddit_instance()
         self.__check_instance_validity()
 
     def build_reddit_instance(self) -> praw.Reddit or None:
         self.log.debug('Building reddit instance')
+
         instance = praw.Reddit(
-            user_agent='MyReddit-dl',
-            client_id=self.config['REDDIT']['client_id'],
-            client_secret=self.config['REDDIT']['client_secret'],
-            username=self.config['REDDIT']['username'],
-            password=self.config['REDDIT']['password'])
+            user_agent = 'MyReddit-dl',
+            client_id = self.config[self.user_section_name]['client_id'],
+            client_secret = self.config[self.user_section_name]['client_secret'],
+            username = self.config[self.user_section_name]['username'],
+            password = self.config[self.user_section_name]['password'])
 
         try:
             if instance.user.me() is not None:
-                self.username = instance.user.me()
-                self.log.info('Reddit Instance build status: OK!')
+                self.user_instance = instance.user.me()
                 return instance
+                # TODO: maybe this is not needed. Make sure the instance is correct elsewhere?
+                #if str(instance.user.me()).lower() == self.username:
+                    #self.log.info('Reddit Instance build status: OK!')
+                    #return instance
+                #self.log.info('Error in reddit instance build')
         except BaseException:
             self.log.exception('Reddit instance build status: Failed')
             return None
@@ -86,7 +91,7 @@ class RedditClient:
             user asked for the saved files with the (-U --upvote) flag.
             Otherwise, return None
         '''
-        return self.username.upvoted(
+        return self.user_instance.upvoted(
             limit=self.args['max_depth']) if self.args['upvote'] else None
 
     @property
@@ -95,7 +100,7 @@ class RedditClient:
             user asked for the saved files with the (-S --saved) flag.
             Otherwise, return None
         '''
-        return self.username.saved(
+        return self.user_instance.saved(
             limit=self.args['max_depth']) if self.args['saved'] else None
 
 

--- a/myreddit-dl/reddit_client.py
+++ b/myreddit-dl/reddit_client.py
@@ -66,7 +66,7 @@ class RedditClient(Defaults):
             Terminal().client_config_setup()
             exit(0)
         if self.arg_dict['change_client']:
-            Terminal().change_client(self.arg_dict['change_client'])
+            Terminal().change_client()
             #self.set_path_to_default()
             exit(0)
         elif self.arg_dict['config_prefix']:

--- a/myreddit-dl/terminal.py
+++ b/myreddit-dl/terminal.py
@@ -50,14 +50,34 @@ class Terminal:
 
         return
 
-    def change_client(self, username: str) -> str:
-        if self.config.has_section(username.upper()):
-            print(f'Config has {username.upper()} section')
-        else:
-            print(f'NO Config for {username.upper()} was found...')
+    def change_client(self):
+        invalid_sections = {'DEFAULTS', 'USERS', 'REDDIT'}
+        sections = [sec for sec in self.config.sections() if sec not in invalid_sections]
+        options = {}
+        res = ''
+        print('\nValid Reddit clients:\n')
+        for i, section in enumerate(sections, 1):
+            print(f'{i}. {self.config[section]["username"]}')
+            options[str(i)] = self.config[section]['username']
+        options[str(len(sections)+1)] = 'Exit'
+        print(f'{len(sections)+1}. Exit Program')
 
 
+        while res not in list(options.keys()):
+            res = input('\nPlease chose the client you want to change to: ')
 
+        if res == str(len(sections) + 1):
+            exit(0)
+
+        if self.config['USERS']['current_user_section_name'] == options[res].upper():
+            self.log.info(f'{options[res]} is already the current reddit client.')
+            exit(0)
+
+
+        self.config['USERS']['current_user_section_name'] = options[res].upper()
+        with open(utils.CFG_FILENAME, 'w') as config_file:
+            self.config.write(config_file)
+            self.log.info(f'Reddit client changed to {options[res]}')
 
 
     def _prompt_user_change(self, username: str) -> str:


### PR DESCRIPTION
- Added `--add-client` flag that will let the user to add additional Reddit clients.
- Added `--change-client` that enables changing from added valid Reddit clients (`--add-client`) must be used first.
- Fixed the `--get-config` flag . It now returns all the configuration file (`--get-config-show`) it's still needed to show passwords

Note: this is more of a minimal viable product (MPV). This implementation will be optimized on a later patch.