### PR TITLE
Metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@ myredditdl.egg-info/*
 debug_media/
 debug.log
 reddit_media/
-media/
 test_dir/
 *.json

--- a/myredditdl/console_args.py
+++ b/myredditdl/console_args.py
@@ -22,6 +22,10 @@ def check_config_requests():
             exit(0)
 
 
+def check_metadata_requests():
+    args = get_console_args()
+
+
 def get_console_args():
     parser = argparse.ArgumentParser(
         description='Reddit upvoted & saved media downloader',

--- a/myredditdl/defaults.py
+++ b/myredditdl/defaults.py
@@ -1,6 +1,7 @@
 import pathlib
 import os
 import myredditdl.utils as utils
+from myredditdl.console_args import get_console_args
 from myredditdl.config_handler import ConfigHandler
 
 
@@ -8,6 +9,7 @@ class Defaults:
     def __init__(self, debug=False) -> None:
         self.log = utils.setup_logger(__name__)
         self.config_handler = ConfigHandler()
+        self.args = get_console_args()
 
     @property
     def home_dir(self) -> str:
@@ -23,8 +25,14 @@ class Defaults:
         return str(pathlib.Path(__file__).parent) + os.sep
 
     @property
-    def media_folder(self) -> str:
-        return self.src_dir + 'media' + os.sep
+    def debug_media_dir(self) -> str:
+        ''' Source files folder'''
+        return str(pathlib.Path(__file__).parent) + \
+            os.sep + 'debug_media' + os.sep
+
+    @property
+    def metadata_folder(self) -> str:
+        return self.src_dir + 'metadata' + os.sep
 
     @property
     def debug_log_file(self) -> str:
@@ -35,13 +43,22 @@ class Defaults:
         return str(self.project_parent_dir + 'debug_media' + os.sep)
 
     @property
+    def metadata_suffix(self):
+        return '_debug.json' if self.args['debug'] else '_metadata.json'
+
+    @property
     def metadata_file(self) -> str:
         ''' Returns the full path of the metadata file'''
-        return self.media_folder + self.client_username + '_metadata.json'
+        return str(self.metadata_folder +
+                   self.config_handler.get_client_username() +
+                   self.metadata_suffix)
 
     @property
     def media_path(self):
-        return self.config_handler.get_media_path()
+        if self.args['debug']:
+            return self.debug_media_dir
+        else:
+            return self.config_handler.get_media_path()
 
     @property
     def current_prefix(self):

--- a/myredditdl/defaults.py
+++ b/myredditdl/defaults.py
@@ -49,9 +49,8 @@ class Defaults:
     @property
     def metadata_file(self) -> str:
         ''' Returns the full path of the metadata file'''
-        return str(self.metadata_folder +
-                   self.config_handler.get_client_username() +
-                   self.metadata_suffix)
+        username = self.config_handler.get_client_username()
+        return self.metadata_folder + username + self.metadata_suffix
 
     @property
     def media_path(self):

--- a/myredditdl/downloader.py
+++ b/myredditdl/downloader.py
@@ -91,6 +91,9 @@ class Downloader(RedditClient):
                 self.log.info(
                     f'Item added: {self.file_handler.get_filename(i)}')
 
+        if not self.args['no_metadata']:
+            self.file_handler.save_metadata()
+
     def get_data(self) -> list:
         return [{'url': self.item.get_media_url()[i],
                  'path': self.file_handler.absolute_path[i]}
@@ -122,6 +125,10 @@ class Downloader(RedditClient):
             self.__iterate_items(self.client_saves)
         else:
             self.log.error(utils.MISSING_DOWNLOAD_SOURCE)
+
+        # TODO: clean folders if --debug flag
+        if self.args['debug']:
+            self.file_handler.debug_clean()
 
         self.log.info(self)
 

--- a/myredditdl/file_handler.py
+++ b/myredditdl/file_handler.py
@@ -3,14 +3,12 @@ import json
 import shutil
 from urllib.parse import urlparse
 import myredditdl.utils as utils
-#from myredditdl.console_args import get_console_args as args
 from myredditdl.defaults import Defaults
 
 
 class FileHandler:
     def __init__(self):
         self.log = utils.setup_logger(__name__, True)
-        #self.log = utils.setup_logger(__name__, args()['debug'])
         self.item = None
         self.defaults = Defaults()
 

--- a/myredditdl/file_handler.py
+++ b/myredditdl/file_handler.py
@@ -1,13 +1,16 @@
 import os
+import json
+import shutil
 from urllib.parse import urlparse
 import myredditdl.utils as utils
-from myredditdl.console_args import get_console_args as args
+#from myredditdl.console_args import get_console_args as args
 from myredditdl.defaults import Defaults
 
 
 class FileHandler:
     def __init__(self):
-        self.log = utils.setup_logger(__name__, args()['debug'])
+        self.log = utils.setup_logger(__name__, True)
+        #self.log = utils.setup_logger(__name__, args()['debug'])
         self.item = None
         self.defaults = Defaults()
 
@@ -19,6 +22,12 @@ class FileHandler:
     def absolute_path(self) -> list:
         return [self.media_path + self._filename(url, str(i))
                 for i, url in enumerate(self.item.get_media_url())]
+
+    def _filename(self, url: str, index='') -> str:
+        extension = self.get_extension(url)
+        prefix = self.defaults.current_prefix
+        index = '' if index == '0' else index
+        return self.prefix_map().get(prefix) + self.item.get_id() + index + extension
 
     def set_current_item(self, item: 'Reddit post item'):
         self.item = item
@@ -38,12 +47,6 @@ class FileHandler:
             self.log.info(f'Path created: {self.media_path}')
         except Exception:
             self.log.bebug(f'invalid path: {self.media_path}')
-
-    def _filename(self, url: str, index='') -> str:
-        extension = self.get_extension(url)
-        prefix = self.defaults.current_prefix
-        index = '' if index == '0' else index
-        return self.prefix_map().get(prefix) + self.item.get_id() + index + extension
 
     def get_extension(self, url: str) -> str:
         try:
@@ -68,79 +71,40 @@ class FileHandler:
         _, filename = os.path.split(self.absolute_path[index])
         return filename
 
-    def _get_item_metadata(self) -> dict:
-        return {'Author': self.item.get_author(),
-                'Subreddit': self.item.get_subreddit_prefixed(),
-                'Title': self.item.get_title(),
-                'Link': self.item.get_reddit_link(),
-                'Upvotes': self.item.get_upvotes_amount(),
-                'NSFW': self.item.is_nsfw(),
-                'Post creation date': self.item.get_creation_date()
-                }
+    def save_metadata(self) -> None:
+        filename = self.get_filename(0)
+        try:
+            with open(self.defaults.metadata_file, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                if filename not in data:
+                    data[filename] = self.item.get_metadata()
+                    self.log.debug(f'Metadata addition: {filename}')
+                else:
+                    self.log.debug(f'Metadata exists: {filename}')
 
-        #
-        #    def delete_database(self) -> None:
-        #        try:
-        #            if os.path.isfile(self.json_file):
-        #                os.remove(self.json_file)
-        #                self.log.debug('Database deleted')
-        #        except IOError:
-        #            self.log.error('While deleting database')
-        #
-        #
-        #    def get_filename_from_path(self, path: str):
-        #        return path.rpartition(os.sep)[-1]
-        #
-        #
-        #    def save_metadata(self, path: str, filename: str):
-        #        try:
-        #            with open(self.json_file, 'r') as f:
-        #                data = json.load(f)
-        #                if filename not in data:
-        #                    data[filename] = self._get_item_metadata()
-        #                    if self.cls.args['verbose']:
-        #                        self.log.debug(f'Added to database: {filename}')
-        #                else:
-        #                    self.log.debug(f'Already in database: {filename}')
-        #
-        #        except IOError:
-        #            self.log.debug(f'Database created for {self.cls.user}')
-        #            data = {f'{filename}': self._get_item_metadata()}
-        #
-        #        with open(self.json_file, 'w') as f:
-        #            json.dump(data, f, indent=4)
-        #
-        #    def get_metadata(self, filename, meta_type=None):
-        #        try:
-        #            with open(self.json_file, 'r') as f:
-        #                data = json.load(f)
-        #                if filename in data.keys():
-        #                    if meta_type:
-        #                        utils.print_data(
-        #                            f'[{meta_type.upper()}] {data[filename][meta_type]}')
-        #                    else:
-        #                        utils.print_metadata(f'{data[filename]}')
-        #                else:
-        #                    self.log.error(f'No data found for {filename}')
-        #
-        #        except IOError:
-        #            self.log.error('Database not found. Must download content first')
-        #
-        #    def clean_debug(self):
-        #        try:
-        #            os.removedirs(self.defaults.debug_path)
-        #            self.log.info('debug_media/ removed')
-        #
-        #        except:
-        #            self.log.info('No debug_media folder to delete')
-        #
-        #        try:
-        #            os.remove(self.defaults.debug_log_file)
-        #            self.log.info('debug_log file removed')
-        #
-        #        except:
-        #            self.log.info('No debug_log file found')
-        #        exit(0)
+        except Exception:
+            self.log.debug(
+                f'Metadata file created: {self.defaults.metadata_file}')
+            data = {f'{filename}': self.item.get_metadata()}
+
+        with open(self.defaults.metadata_file, 'w') as f:
+            json.dump(data, f, indent=4)
+
+    def debug_clean(self) -> None:
+        try:
+            shutil.rmtree(self.defaults.debug_media_dir)
+            self.log.debug('Debug media folder removed')
+
+        except FileNotFoundError:
+            self.log.debug('No debug media folder found')
+
+        try:
+            os.remove(self.defaults.metadata_file)
+            self.log.debug(
+                f'Metadata file removed: {self.defaults.metadata_file}')
+
+        except FileNotFoundError:
+            self.log.debug('No debug metadata file found')
 
 
 if __name__ == '__main__':

--- a/myredditdl/item.py
+++ b/myredditdl/item.py
@@ -127,6 +127,15 @@ class Item:
         time_utc = self.__item.created_utc
         return str(datetime.fromtimestamp(time_utc).strftime('%m/%d/%Y'))
 
+    def get_metadata(self) -> dict:
+        return {'Author': self.get_author(),
+                'Subreddit': self.get_subreddit_prefixed(),
+                'Title': self.get_title(),
+                'Link': self.get_reddit_link(),
+                'Upvotes': self.get_upvotes_amount(),
+                'NSFW': self.is_nsfw(),
+                'Post creation date': self.get_creation_date()}
+
     def _fetch_media_url(self) -> list:
         ''' Returns a list of media url(s) for the given post item
 

--- a/myredditdl/myredditdl.py
+++ b/myredditdl/myredditdl.py
@@ -13,6 +13,7 @@ from myredditdl.downloader import Downloader
 def run():
     if len(sys.argv) > 1:
         console_args.check_config_requests()
+        console_args.check_metadata_requests()
         Downloader().start()
 
     # GUI version of the app

--- a/myredditdl/reddit_client.py
+++ b/myredditdl/reddit_client.py
@@ -31,6 +31,9 @@ class RedditClient:
             user asked for the saved files with the (-U --upvote) flag.
             Otherwise, return None
         '''
+        if self.user_instance is None:
+            self.logger.warning('User instance is None. Fix me!')
+            return ()
         return self.user_instance.upvoted(
             limit=self.arg_dict['max_depth']) if self.arg_dict['upvote'] else None
 
@@ -40,6 +43,9 @@ class RedditClient:
             user asked for the saved files with the (-S --saved) flag.
             Otherwise, return None
         '''
+        if self.user_instance is None:
+            self.logger.warning('User instance is None. Fix me!')
+            return ()
         return self.user_instance.saved(
             limit=self.arg_dict['max_depth']) if self.arg_dict['saved'] else None
 


### PR DESCRIPTION
This PR adds basic metadata file handling  and debug files/folders handling.

More work should be done on the `save_metadata` function in `file_handler.py`.
Right now the saving is done by opening the metadata file for each of the items. That is costly and should be refactored to saving all the metadata in one opening.